### PR TITLE
Fix README and move to using conda environment specification.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Author: Alexander Kagoshima
 
 This app demonstrates a very simple API that can be used to create model instances, feed data to them and let these models retrain periodically. Currently, it uses redis to store model instances, model state and data as well - for scalability and distributed processing of data this should be replaced by a distributed data storage.
 
+Requirements: A Redis CF service instance with the name `rediscloud`.
+
+Host names in a Cloud Foundry installation need to be globally unique.
+In order to push your own version of this application to Pivotal Web Services
+please change the host name in `manifest.yml`
+or specify on the command line using `cf push -n myhostname`.
+
+
 For all the tests below replace ```http://<model_domain>``` with your Cloud Foundry app domain.
 
 
@@ -53,7 +61,9 @@ Look at all created models
 
 There's a very rudimentary view on the redis set of all models that have been created:
 
-```http://<model_domain>/models/```
+```
+http://<model_domain>/models/
+```
 
 
 Look at model details
@@ -61,7 +71,9 @@ Look at model details
 
 This lets you check out the status of the previously created model as well as its trained parameters:
 
-```http://<model_domain>/models/model1```
+```
+http://<model_domain>/models/model1
+```
 
 
 Todo

--- a/conda_requirements.txt
+++ b/conda_requirements.txt
@@ -1,1 +1,0 @@
-scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+name: cfpylearning
+dependencies:
+- flask=0.10.1=py27_1
+- itsdangerous=0.24=py27_0
+- jinja2=2.7.3=py27_1
+- markdown=2.6.2=py27_0
+- markupsafe=0.23=py27_0
+- nose=1.3.7=py27_0
+- numpy=1.9.2=py27_0
+- openssl=1.0.1k=1
+- pip=7.0.3=py27_0
+- python=2.7.10=0
+- readline=6.2=2
+- scikit-learn=0.16.1=np19py27_0
+- scipy=0.15.1=np19py27_0
+- setuptools=17.1.1=py27_0
+- sqlite=3.8.4.1=1
+- tk=8.5.18=0
+- werkzeug=0.10.4=py27_0
+- zlib=1.2.8=0
+- pip:
+  - redis==2.10.3

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,5 @@ applications:
   host: dsoncf
   domain: cfapps.io
   path: .
-  command: .conda/bin/python main.py
+  buildpack: https://github.com/ihuston/python-conda-buildpack.git
+  command: python main.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-Flask
-redis
-markdown


### PR DESCRIPTION
The conda buildpack now understands conda environment specification files from conda-env so I've updated the app to use this instead of separate requirements files.

Also included a few other minor changes, including fixing README formatting.
